### PR TITLE
Read the correct amount of attributes

### DIFF
--- a/bta/gatt/bta_gattc_cache.c
+++ b/bta/gatt/bta_gattc_cache.c
@@ -1565,7 +1565,7 @@ bool bta_gattc_cache_load(tBTA_GATTC_CLCB *p_clcb)
 
     attr = osi_malloc(sizeof(tBTA_GATTC_NV_ATTR) * num_attr);
 
-    if (fread(attr, sizeof(tBTA_GATTC_NV_ATTR), 0xFF, fd) != num_attr) {
+    if (fread(attr, sizeof(tBTA_GATTC_NV_ATTR), num_attr, fd) != num_attr) {
         APPL_TRACE_ERROR("%s: can't read GATT attributes: %s", __func__, fname);
         goto done;
     }


### PR DESCRIPTION
bta_gattc_cache_load currently attempts to read 0xFF attributes into an
allocation sized to num_attr attributes, which can be smaller than 0xFF.

There aren't more than num_attr bytes in correct data, but this breaks
with dynamic buffer overflow checking in CopperheadOS for the read
system call since fread ends up calling read, which obtains the size of
the allocation from the malloc implementation and then aborts due to the
(potential) overflow.

This would also fail with the default enabled _FORTIFY_SOURCE=2 feature
in the Android Open Source Project if osi_malloc was marked with the
alloc_size attribute. The way it wraps malloc loses that information so
fortify checks aren't done for calls like this.

Bug: 37160362
Change-Id: I68bd170d5378c9d9d21cbda376083bc0b857e15c
(cherry picked from commit 68a1cf1)
Source: LineageOS (grandforked from AOSP)